### PR TITLE
Fix phpdoc @param tags with the NULL type

### DIFF
--- a/src/Transformation/Adjustment/Improve.php
+++ b/src/Transformation/Adjustment/Improve.php
@@ -31,8 +31,8 @@ class Improve extends BlendEffectQualifier
     /**
      * Improve constructor.
      *
-     * @param      $blend
-     * @param null $mode
+     * @param       $blend
+     * @param mixed $mode
      */
     public function __construct($blend = null, $mode = null)
     {

--- a/src/Transformation/Background/AutoGradientBackground.php
+++ b/src/Transformation/Background/AutoGradientBackground.php
@@ -44,7 +44,7 @@ class AutoGradientBackground extends AutoBackground
      *
      * @param string     $mode              The auto background mode.
      * @param int|string $gradientColors    The number of gradient colors to select. Possible values: 2 or 4. Default: 2
-     * @param null       $gradientDirection The direction. Use the constants defined in the GradientDirection class.
+     * @param string     $gradientDirection The direction. Use the constants defined in the GradientDirection class.
      */
     public function __construct($mode, $gradientColors = null, $gradientDirection = null)
     {

--- a/src/Transformation/Border/BorderValue.php
+++ b/src/Transformation/Border/BorderValue.php
@@ -28,9 +28,9 @@ class BorderValue extends QualifierMultiValue
     /**
      * BorderValue constructor.
      *
-     * @param null $color
-     * @param null $width
-     * @param null $style
+     * @param string     $color
+     * @param int|string $width
+     * @param string     $style
      */
     public function __construct($color = null, $width = null, $style = null)
     {

--- a/src/Transformation/CommonTransformation.php
+++ b/src/Transformation/CommonTransformation.php
@@ -28,7 +28,7 @@ class CommonTransformation extends BaseComponent implements CommonTransformation
     /**
      * CommonTransformation constructor.
      *
-     * @param null $transformation
+     * @param mixed $transformation
      */
     public function __construct($transformation = null)
     {

--- a/src/Transformation/CustomFunction/CustomFunctionValue.php
+++ b/src/Transformation/CustomFunction/CustomFunctionValue.php
@@ -23,9 +23,9 @@ class CustomFunctionValue extends QualifierMultiValue
     /**
      * CustomFunctionValue constructor.
      *
-     * @param null $source
-     * @param null $type
-     * @param null $preprocess
+     * @param mixed $source
+     * @param mixed $type
+     * @param mixed $preprocess
      */
     public function __construct($source = null, $type = null, $preprocess = null)
     {

--- a/src/Transformation/Delivery/Quality/QualityQualifier.php
+++ b/src/Transformation/Delivery/Quality/QualityQualifier.php
@@ -10,6 +10,7 @@
 
 namespace Cloudinary\Transformation;
 
+use Cloudinary\Transformation\BaseComponent;
 use Cloudinary\Transformation\Qualifier\BaseExpressionQualifier;
 
 /**
@@ -60,9 +61,9 @@ class QualityQualifier extends BaseExpressionQualifier
     /**
      * Quality constructor.
      *
-     * @param       $strength
-     * @param null  $preset
-     * @param array $values
+     * @param mixed               $strength
+     * @param mixed|BaseComponent $preset
+     * @param mixed               $values
      */
     public function __construct($strength, $preset = null, ...$values)
     {

--- a/src/Transformation/Effect/Color/AssistColorBlind.php
+++ b/src/Transformation/Effect/Color/AssistColorBlind.php
@@ -22,7 +22,7 @@ class AssistColorBlind extends LimitedEffectQualifier
     /**
      * AssistColorBlind constructor.
      *
-     * @param null $strength
+     * @param string $strength
      */
     public function __construct($strength = null)
     {

--- a/src/Transformation/Effect/Color/SimulateColorBlind.php
+++ b/src/Transformation/Effect/Color/SimulateColorBlind.php
@@ -53,7 +53,7 @@ class SimulateColorBlind extends ValueEffectQualifier
     /**
      * SimulateColorBlind constructor.
      *
-     * @param null $condition
+     * @param string $condition
      */
     public function __construct($condition = null)
     {

--- a/src/Transformation/Effect/EffectActionTrait.php
+++ b/src/Transformation/Effect/EffectActionTrait.php
@@ -31,9 +31,9 @@ trait EffectActionTrait
     }
 
     /**
-     * @param       $effectName
-     * @param null  $value
-     * @param mixed ...$args
+     * @param string $effectName
+     * @param mixed  $value
+     * @param mixed  ...$args
      *
      * @return EffectAction
      */
@@ -43,10 +43,10 @@ trait EffectActionTrait
     }
 
     /**
-     * @param       $effectName
-     * @param       $range
-     * @param null  $value
-     * @param mixed ...$args
+     * @param string $effectName
+     * @param array  $range
+     * @param mixed  $value
+     * @param mixed  ...$args
      *
      * @return EffectAction
      */
@@ -56,10 +56,10 @@ trait EffectActionTrait
     }
 
     /**
-     * @param       $effectName
-     * @param       $range
-     * @param null  $value
-     * @param mixed ...$args
+     * @param string $effectName
+     * @param array  $range
+     * @param mixed  $value
+     * @param mixed  ...$args
      *
      * @return LevelEffectAction
      */
@@ -69,10 +69,10 @@ trait EffectActionTrait
     }
 
     /**
-     * @param       $effectName
-     * @param       $range
-     * @param null  $value
-     * @param mixed ...$args
+     * @param string $effectName
+     * @param array  $range
+     * @param mixed  $value
+     * @param mixed  ...$args
      *
      * @return StrengthEffectAction
      */
@@ -82,10 +82,10 @@ trait EffectActionTrait
     }
 
     /**
-     * @param       $effectName
-     * @param       $range
-     * @param null  $value
-     * @param mixed ...$args
+     * @param string $effectName
+     * @param array  $range
+     * @param mixed  $value
+     * @param mixed  ...$args
      *
      * @return BlendEffectAction
      */
@@ -95,10 +95,10 @@ trait EffectActionTrait
     }
 
     /**
-     * @param       $effectName
-     * @param       $range
-     * @param null  $value
-     * @param mixed ...$args
+     * @param string $effectName
+     * @param array  $range
+     * @param mixed  $value
+     * @param mixed  ...$args
      *
      * @return ThresholdEffectAction
      */
@@ -108,9 +108,9 @@ trait EffectActionTrait
     }
 
     /**
-     * @param       $effectName
-     * @param null  $value
-     * @param mixed ...$args
+     * @param string $effectName
+     * @param mixed  $value
+     * @param mixed  ...$args
      *
      * @return DurationEffectAction
      */
@@ -120,9 +120,9 @@ trait EffectActionTrait
     }
 
     /**
-     * @param       $effectName
-     * @param null  $value
-     * @param mixed ...$args
+     * @param string $effectName
+     * @param array  $value
+     * @param mixed  ...$args
      *
      * @return ToleranceEffectAction
      */

--- a/src/Transformation/Effect/LimitedEffectQualifier.php
+++ b/src/Transformation/Effect/LimitedEffectQualifier.php
@@ -29,10 +29,10 @@ class LimitedEffectQualifier extends ValueEffectQualifier
     /**
      * LimitedEffectQualifier constructor.
      *
-     * @param       $effectName
-     * @param       $range
-     * @param       $level
-     * @param array $args
+     * @param string $effectName
+     * @param array  $range
+     * @param mixed  $level
+     * @param array  $args
      */
     public function __construct($effectName, $range, $level = null, ...$args)
     {

--- a/src/Transformation/Effect/Misc/Cartoonify.php
+++ b/src/Transformation/Effect/Misc/Cartoonify.php
@@ -30,9 +30,9 @@ class Cartoonify extends LimitedEffectQualifier
     /**
      * Trim constructor.
      *
-     * @param null  $lineStrength
-     * @param null  $colorReduction
-     * @param array $args
+     * @param float        $lineStrength
+     * @param float|string $colorReduction
+     * @param array        $args
      */
     public function __construct($lineStrength = null, $colorReduction = null, ...$args)
     {

--- a/src/Transformation/Effect/Misc/Shadow.php
+++ b/src/Transformation/Effect/Misc/Shadow.php
@@ -23,10 +23,10 @@ class Shadow extends StrengthEffectAction
     /**
      * Shadow constructor.
      *
-     * @param        $strength
-     * @param null   $offsetX
-     * @param null   $offsetY
-     * @param null   $color
+     * @param int              $strength
+     * @param float|int|string $offsetX
+     * @param float|int|string $offsetY
+     * @param string           $color
      */
     public function __construct($strength = null, $offsetX = null, $offsetY = null, $color = null)
     {

--- a/src/Transformation/Effect/Misc/StyleTransfer/StyleTransferQualifier.php
+++ b/src/Transformation/Effect/Misc/StyleTransfer/StyleTransferQualifier.php
@@ -24,7 +24,7 @@ class StyleTransferQualifier extends LimitedEffectQualifier
      * StyleTransfer constructor.
      *
      * @param int   $strength
-     * @param null  $preserveColor
+     * @param bool  $preserveColor
      * @param array $args
      */
     public function __construct($strength = null, $preserveColor = null, ...$args)

--- a/src/Transformation/Effect/Misc/VectorizeValue.php
+++ b/src/Transformation/Effect/Misc/VectorizeValue.php
@@ -33,11 +33,11 @@ class VectorizeValue extends QualifierMultiValue
     /**
      * VectorizeValue constructor.
      *
-     * @param null $colors
-     * @param null $detail
-     * @param null $despeckle
-     * @param null $paths
-     * @param null $corners
+     * @param int   $colors
+     * @param float $detail
+     * @param float $despeckle
+     * @param int   $paths
+     * @param int   $corners
      */
     public function __construct($colors = null, $detail = null, $despeckle = null, $paths = null, $corners = null)
     {

--- a/src/Transformation/Effect/Pixel/GradientFade.php
+++ b/src/Transformation/Effect/Pixel/GradientFade.php
@@ -46,8 +46,8 @@ class GradientFade extends StrengthEffectAction
     /**
      * GradientFade constructor.
      *
-     * @param      $strength
-     * @param null $type
+     * @param int|string $strength
+     * @param string     $type
      */
     public function __construct($strength = null, $type = null)
     {

--- a/src/Transformation/Effect/Pixel/RegionEffectAction.php
+++ b/src/Transformation/Effect/Pixel/RegionEffectAction.php
@@ -10,6 +10,8 @@
 
 namespace Cloudinary\Transformation;
 
+use Cloudinary\Transformation\Region;
+
 /**
  * Class RegionEffectAction
  */
@@ -20,11 +22,11 @@ class RegionEffectAction extends EffectAction
     /**
      * RegionEffectAction constructor.
      *
-     * @param       $effectName
-     * @param       $range
-     * @param       $strength
-     * @param null  $region
-     * @param mixed ...$args
+     * @param string $effectName
+     * @param array  $range
+     * @param mixed  $strength
+     * @param Region $region
+     * @param mixed  ...$args
      */
     public function __construct($effectName, $range, $strength = null, $region = null, ...$args)
     {

--- a/src/Transformation/Effect/Playback/Preview.php
+++ b/src/Transformation/Effect/Playback/Preview.php
@@ -22,9 +22,9 @@ class Preview extends EffectAction
     /**
      * Preview constructor.
      *
-     * @param null $duration
-     * @param null $maximumSegments
-     * @param null $minimumSegmentDuration
+     * @param mixed|object $duration
+     * @param mixed        $maximumSegments
+     * @param mixed        $minimumSegmentDuration
      */
     public function __construct($duration = null, $maximumSegments = null, $minimumSegmentDuration = null)
     {
@@ -36,7 +36,7 @@ class Preview extends EffectAction
     }
 
     /**
-     * @param $duration
+     * @param mixed|object $duration
      *
      * @return Preview
      */

--- a/src/Transformation/Layer/TextSource.php
+++ b/src/Transformation/Layer/TextSource.php
@@ -10,8 +10,11 @@
 
 namespace Cloudinary\Transformation;
 
+use Cloudinary\Transformation\Argument\ColorValue;
 use Cloudinary\Transformation\Argument\Text\Stroke;
 use Cloudinary\Transformation\Argument\Text\TextStyleTrait;
+use Cloudinary\Transformation\Background;
+use Cloudinary\Transformation\TextStyle;
 
 /**
  * Defines how to manipulate a text layer.
@@ -36,10 +39,10 @@ class TextSource extends BaseSource implements ImageTransformationInterface
     /**
      * TextLayer constructor.
      *
-     * @param string $text
-     * @param null   $style
-     * @param null   $color
-     * @param null   $backgroundColor
+     * @param string                       $text
+     * @param string|TextStyle             $style
+     * @param string                       $color
+     * @param string|Background|ColorValue $backgroundColor
      */
     public function __construct($text = null, $style = null, $color = null, $backgroundColor = null)
     {

--- a/src/Transformation/Positioning/CompassGravityTrait.php
+++ b/src/Transformation/Positioning/CompassGravityTrait.php
@@ -25,7 +25,7 @@ trait CompassGravityTrait
      * The compass direction represents a location in the image, for example, Gravity::northEast() represents the
      * top right corner.
      *
-     * @param $compassGravity
+     * @param string $compassGravity
      *
      * @return static
      *

--- a/src/Transformation/Positioning/CompassPosition.php
+++ b/src/Transformation/Positioning/CompassPosition.php
@@ -20,9 +20,9 @@ class CompassPosition extends BasePosition
     /**
      * CompassPosition constructor.
      *
-     * @param null $gravity
-     * @param null $x Offset x
-     * @param null $y Offset y
+     * @param string           $gravity
+     * @param float|int|string $x Offset x
+     * @param float|int|string $y Offset y
      */
     public function __construct($gravity = null, $x = null, $y = null)
     {

--- a/src/Transformation/Positioning/FocalGravityTrait.php
+++ b/src/Transformation/Positioning/FocalGravityTrait.php
@@ -20,7 +20,7 @@ trait FocalGravityTrait
     /**
      * Sets the focal gravity for resizing.
      *
-     * @param $focalGravity
+     * @param mixed $focalGravity
      *
      * @return $this
      */

--- a/src/Transformation/Positioning/Offset.php
+++ b/src/Transformation/Positioning/Offset.php
@@ -20,8 +20,8 @@ class Offset extends BaseAction
     /**
      * Offset constructor.
      *
-     * @param null $x
-     * @param null $y
+     * @param float|int|string $x
+     * @param float|int|string $y
      */
     public function __construct($x = null, $y = null)
     {

--- a/src/Transformation/Positioning/Point.php
+++ b/src/Transformation/Positioning/Point.php
@@ -20,8 +20,8 @@ class Point extends BaseAction
     /**
      * Point constructor.
      *
-     * @param null $x
-     * @param null $y
+     * @param float|int|string $x
+     * @param float|int|string $y
      */
     public function __construct($x = null, $y = null)
     {

--- a/src/Transformation/Qualifier/Dimensions/Dimensions.php
+++ b/src/Transformation/Qualifier/Dimensions/Dimensions.php
@@ -10,7 +10,9 @@
 
 namespace Cloudinary\Transformation\Qualifier\Dimensions;
 
+use Cloudinary\Transformation\AspectRatio;
 use Cloudinary\Transformation\BaseAction;
+use Cloudinary\Transformation\Expression\Expression;
 
 /**
  * Class Dimensions
@@ -22,9 +24,9 @@ class Dimensions extends BaseAction
     /**
      * Dimensions constructor.
      *
-     * @param null  $width
-     * @param null  $height
-     * @param mixed ...$aspectRatio
+     * @param int|string|Expression $width
+     * @param int|string|Expression $height
+     * @param mixed|AspectRatio     ...$aspectRatio
      */
     public function __construct($width = null, $height = null, ...$aspectRatio)
     {

--- a/src/Transformation/Qualifier/QualifierValue/Canvas/PointValue.php
+++ b/src/Transformation/Qualifier/QualifierValue/Canvas/PointValue.php
@@ -30,8 +30,8 @@ class PointValue extends BaseComponent
     /**
      * PointValue constructor.
      *
-     * @param null $x
-     * @param null $y
+     * @param int $x
+     * @param int $y
      */
     public function __construct($x = null, $y = null)
     {

--- a/src/Transformation/Qualifier/QualifierValue/Color/Gradient.php
+++ b/src/Transformation/Qualifier/QualifierValue/Color/Gradient.php
@@ -62,9 +62,9 @@ class Gradient extends BaseComponent
     /**
      * Gradient constructor.
      *
-     * @param null $type
-     * @param null $numberOfColors
-     * @param null $direction
+     * @param string $type
+     * @param int    $numberOfColors
+     * @param string $direction
      */
     public function __construct($type = null, $numberOfColors = null, $direction = null)
     {

--- a/src/Transformation/Qualifier/QualifierValue/Text/Text.php
+++ b/src/Transformation/Qualifier/QualifierValue/Text/Text.php
@@ -25,7 +25,7 @@ class Text extends QualifierMultiValue
     /**
      * Text constructor
      *
-     * @param null $text
+     * @param string $text
      */
     public function __construct($text = null)
     {

--- a/src/Transformation/Qualifier/QualifierValue/Text/TextStyle.php
+++ b/src/Transformation/Qualifier/QualifierValue/Text/TextStyle.php
@@ -44,8 +44,8 @@ class TextStyle extends QualifierMultiValue
     /**
      * TextStyle constructor
      *
-     * @param null $fontFamily
-     * @param null $fontSize
+     * @param string    $fontFamily
+     * @param float|int $fontSize
      */
     public function __construct($fontFamily = null, $fontSize = null)
     {

--- a/src/Transformation/Qualifier/Timeline/Timeline.php
+++ b/src/Transformation/Qualifier/Timeline/Timeline.php
@@ -32,9 +32,9 @@ class Timeline extends BaseQualifier
     /**
      * Region constructor.
      *
-     * @param null $startOffset
-     * @param null $endOffset
-     * @param null $duration
+     * @param mixed $startOffset
+     * @param mixed $endOffset
+     * @param mixed $duration
      */
     public function __construct($startOffset = null, $endOffset = null, $duration = null)
     {

--- a/src/Transformation/Resize/BaseResizeAction.php
+++ b/src/Transformation/Resize/BaseResizeAction.php
@@ -12,6 +12,7 @@ namespace Cloudinary\Transformation;
 
 use Cloudinary\ArrayUtils;
 use Cloudinary\ClassUtils;
+use Cloudinary\Transformation\Expression\Expression;
 use Cloudinary\Transformation\Expression\ExpressionUtils;
 use Cloudinary\Transformation\Qualifier\Dimensions\Dimensions;
 use Cloudinary\Transformation\Qualifier\Dimensions\DimensionsTrait;
@@ -33,9 +34,9 @@ abstract class BaseResizeAction extends BaseAction
     /**
      * BaseResize constructor.
      *
-     * @param string|CropMode $cropMode The crop mode.
-     * @param null            $width    Optional. Width.
-     * @param null            $height   Optional. Height.
+     * @param string|CropMode       $cropMode The crop mode.
+     * @param int|string|Expression $width    Optional. Width.
+     * @param int|string|Expression $height   Optional. Height.
      */
     public function __construct($cropMode, $width = null, $height = null)
     {

--- a/src/Transformation/Resize/Crop/Crop.php
+++ b/src/Transformation/Resize/Crop/Crop.php
@@ -10,6 +10,9 @@
 
 namespace Cloudinary\Transformation;
 
+use Cloudinary\Transformation\CropMode;
+use Cloudinary\Transformation\Expression\Expression;
+
 /**
  * Class Crop
  */
@@ -24,12 +27,12 @@ class Crop extends BaseResizeAction
     /**
      * Crop constructor.
      *
-     * @param      $cropMode
-     * @param null $width
-     * @param null $height
-     * @param null $gravity
-     * @param null $x
-     * @param null $y
+     * @param string|CropMode       $cropMode
+     * @param int|string|Expression $width
+     * @param int|string|Expression $height
+     * @param mixed                 $gravity
+     * @param float|int|string      $x
+     * @param float|int|string      $y
      */
     public function __construct($cropMode, $width = null, $height = null, $gravity = null, $x = null, $y = null)
     {

--- a/src/Transformation/Resize/Fill/Fill.php
+++ b/src/Transformation/Resize/Fill/Fill.php
@@ -10,6 +10,9 @@
 
 namespace Cloudinary\Transformation;
 
+use Cloudinary\Transformation\CropMode;
+use Cloudinary\Transformation\Expression\Expression;
+
 /**
  * Class Fill
  */
@@ -22,10 +25,10 @@ class Fill extends BaseResizeAction
     /**
      * Fill constructor.
      *
-     * @param      $cropMode
-     * @param null $width
-     * @param null $height
-     * @param null $gravity
+     * @param string|CropMode       $cropMode
+     * @param int|string|Expression $width
+     * @param int|string|Expression $height
+     * @param mixed                 $gravity
      */
     public function __construct($cropMode, $width = null, $height = null, $gravity = null)
     {

--- a/src/Transformation/Resize/Fill/FillPad.php
+++ b/src/Transformation/Resize/Fill/FillPad.php
@@ -10,6 +10,10 @@
 
 namespace Cloudinary\Transformation;
 
+use Cloudinary\Transformation\Argument\ColorValue;
+use Cloudinary\Transformation\Background;
+use Cloudinary\Transformation\CropMode;
+use Cloudinary\Transformation\Expression\Expression;
 use InvalidArgumentException;
 
 /**
@@ -26,11 +30,11 @@ class FillPad extends Fill
     /**
      * FillPad constructor.
      *
-     * @param      $cropMode
-     * @param null $width
-     * @param null $height
-     * @param null $gravity
-     * @param null $background
+     * @param string|CropMode              $cropMode
+     * @param int|string|Expression        $width
+     * @param int|string|Expression        $height
+     * @param mixed                        $gravity
+     * @param string|Background|ColorValue $background
      */
     public function __construct($cropMode, $width = null, $height = null, $gravity = null, $background = null)
     {

--- a/src/Transformation/Resize/Pad/Pad.php
+++ b/src/Transformation/Resize/Pad/Pad.php
@@ -10,6 +10,10 @@
 
 namespace Cloudinary\Transformation;
 
+use Cloudinary\Transformation\Background;
+use Cloudinary\Transformation\Argument\ColorValue;
+use Cloudinary\Transformation\Expression\Expression;
+
 /**
  * Class BasePad
  */
@@ -20,10 +24,10 @@ class Pad extends BaseResizeAction
     /**
      * Pad constructor.
      *
-     * @param      $cropMode
-     * @param null $width
-     * @param null $height
-     * @param null $background
+     * @param                              $cropMode
+     * @param int|null|string|Expression   $width
+     * @param int|null|string|Expression   $height
+     * @param string|Background|ColorValue $background
      */
     public function __construct(
         $cropMode,

--- a/src/Transformation/Shape/Shear.php
+++ b/src/Transformation/Shape/Shear.php
@@ -23,8 +23,8 @@ class Shear extends EffectQualifier
     /**
      * Shear constructor.
      *
-     * @param null $skewX
-     * @param      $skewY
+     * @param float $skewX
+     * @param float $skewY
      */
     public function __construct($skewX = null, $skewY = null)
     {

--- a/src/Transformation/Video/Argument/Range/MinMaxRange.php
+++ b/src/Transformation/Video/Argument/Range/MinMaxRange.php
@@ -25,8 +25,8 @@ class MinMaxRange extends QualifierMultiValue
     /**
      * MinMaxRange constructor.
      *
-     * @param      $min
-     * @param null $max
+     * @param int $min
+     * @param int $max
      */
     public function __construct($min, $max = null)
     {

--- a/src/Transformation/Video/Argument/Range/Range.php
+++ b/src/Transformation/Video/Argument/Range/Range.php
@@ -34,7 +34,7 @@ class Range implements ComponentInterface
     /**
      * Range constructor.
      *
-     * @param null $range
+     * @param mixed $range
      */
     public function __construct($range = null)
     {

--- a/src/Transformation/Video/Edit/VideoEditBuilderTrait.php
+++ b/src/Transformation/Video/Edit/VideoEditBuilderTrait.php
@@ -22,9 +22,9 @@ trait VideoEditBuilderTrait
     /**
      * Trims a video (and discards the rest).
      *
-     * @param null $startOffset
-     * @param null $endOffset
-     * @param null $duration
+     * @param mixed $startOffset
+     * @param mixed $endOffset
+     * @param mixed $duration
      *
      * @return Timeline
      *

--- a/src/Transformation/Video/Transcode/Codec/VideoCodecTrait.php
+++ b/src/Transformation/Video/Transcode/Codec/VideoCodecTrait.php
@@ -60,8 +60,8 @@ trait VideoCodecTrait
     /**
      * Video codec h264.
      *
-     * @param null $profile
-     * @param null $level
+     * @param string $profile
+     * @param string $level
      *
      * @return VideoCodec
      */

--- a/src/Transformation/Video/Transcode/Fps.php
+++ b/src/Transformation/Video/Transcode/Fps.php
@@ -37,8 +37,8 @@ class Fps extends BaseQualifier
     /**
      * FPS constructor.
      *
-     * @param      $min
-     * @param null $max
+     * @param mixed $min
+     * @param mixed $max
      */
     public function __construct($min = null, $max = null)
     {


### PR DESCRIPTION
### Brief Summary of Changes
Parameters documented by `@param null` make it difficult for IDEs and static analysis tools to reason about the code.
This PR tries to fix the most obvious occurences of the pattern.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests
- [x] Documentation

#### Are tests included?
- [ ] Yes
- [x] No
This PR only contains changes to documentation.

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
