### PR TITLE
Adjust cast and test against PHP 8.5

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,7 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/src/Transformation/Expression/ExpressionUtils.php
+++ b/src/Transformation/Expression/ExpressionUtils.php
@@ -124,6 +124,6 @@ class ExpressionUtils
      */
     protected static function isLiteral(string $expression): bool
     {
-        return (boolean)preg_match('/^!.+!$/', $expression);
+        return (bool)preg_match('/^!.+!$/', $expression);
     }
 }

--- a/src/Transformation/Variable/Variable.php
+++ b/src/Transformation/Variable/Variable.php
@@ -169,7 +169,7 @@ class Variable extends GenericQualifier
      */
     public static function isVariable(string $candidate): bool
     {
-        return (boolean)preg_match('/^\$[a-zA-Z]\w*$/', $candidate);
+        return (bool)preg_match('/^\$[a-zA-Z]\w*$/', $candidate);
     }
 
     /**


### PR DESCRIPTION
### Brief Summary of Changes
I upgraded my project to PHP 8.5 and started seeing deprecation warnings for the `(boolean)` cast:

```
  Non-canonical cast (boolean) is deprecated, use the (bool) cast instead

  at vendor/cloudinary/transformation-builder-sdk/src/Transformation/Qualifier/QualifiersAction.php:255
    251▕         $variables = ArrayUtils::get($options, 'variables', []);
    252▕ 
    253▕         $varQualifiers = [];
    254▕         foreach ($options as $key => $value) {
  ➜ 255▕             if (Variable::isVariable($key)) {
    256▕                 $varQualifiers[] = Variable::set($key, Expression::expression($value));
    257▕             }
    258▕         }
    259▕ 
```

This PR simply updates the `(boolean)` casts to `(bool)` which should be backwards compatible. It also updates the workflow to test against PHP 8.5.

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [x] Refactoring
- [ ] New feature
- [ ] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [X] Yes
- [ ] No

#### Reviewer, please note:
N/A

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
